### PR TITLE
Sistemiamo estrazione header dai post

### DIFF
--- a/scripts/utils.php
+++ b/scripts/utils.php
@@ -54,10 +54,15 @@ function eventMetadata($filename) {
         $contents = file('_posts/' . $filename);
 
         $parsable = [];
+        $in_header = false;
 
         for($i = 1; $i < count($contents); $i++) {
-                if (substr($contents[$i], 0, 3) == '---')
-                        break;
+                if (substr($contents[$i], 0, 3) == '---') {
+                        if ($in_header)
+                                break;
+                        $in_header = true;
+                        continue;
+                }
 
                 $parsable[] = $contents[$i];
         }


### PR DESCRIPTION
Dobbiamo smettere di leggere l'header la seconda volta che leggiamo '---' e non la prima, altrimenti non leggiamo niente :)

La patch è stata editata direttamente in github e non è testata. Sono arrivato qua perchè è stato twittato django girls con la data 01/01 che mi ha fatto pensare ad un valore di default.
