### PR TITLE
Aggiorna l'evento se già esiste

### DIFF
--- a/scripts/utils.php
+++ b/scripts/utils.php
@@ -87,9 +87,6 @@ function saveEvent($object) {
         $date = date('Y-m-d', $object->time);
         $filename = sprintf('_posts/%s-%s.markdown', $date, $slug);
 
-        if (file_exists($filename))
-                return false;
-
         /*
                 A YAML non sembrano piacere i due punti...
         */


### PR DESCRIPTION
Ho provato un po' e mi sembra che non dia problemi, se l'evento non cambia titolo e ora viene sovrascritto.

Tra l'altro se dovesse cambiare titolo e ora già adesso verrebbe duplicato. Semplicemente permette l'aggiornamento ogni giorno dei post. Se lo lanci sul sito dovresti vedere aggiornato l'evento di JUG Torino che nel frattempo è cambiato.

Fixes #8 