### PR TITLE
Try to not duplicate events

### DIFF
--- a/scripts/utils.php
+++ b/scripts/utils.php
@@ -82,10 +82,32 @@ function futureEvents() {
         return $ret;
 }
 
+function findDuplicatedEvent($hash) {
+        $files = array_diff(scandir('_posts/'), ['..', '.']);
+
+        foreach($files as $f) {
+                if (strpos($f, $hash) !== false)
+                        return $f;
+        }
+
+        return false;
+}
+
 function saveEvent($object) {
+        $hash = sha1($object->url);
         $slug = slugify($object->title);
         $date = date('Y-m-d', $object->time);
-        $filename = sprintf('_posts/%s-%s.markdown', $date, $slug);
+
+        /*
+                Per evitare di duplicare eventi che vengono rinominati mettiamo l'hash
+                nel nome per poterlo ricercare. Se lo troviamo riscriviamo quel post
+                piuttosto che crearne uno nuovo.
+         */
+        $oldpost = findDuplicatedEvent($hash);
+        if ($oldpost === false)
+                $filename = sprintf('_posts/%s-%s-$s.markdown', $date, $slug, $hash);
+        else
+                $filename = sprintf('_posts/%s', $oldpost);
 
         /*
                 A YAML non sembrano piacere i due punti...


### PR DESCRIPTION
This is untested and not particularly smart but should fix #19.

Each time an event gets renamed a new post is created. Implement
a poor man solution to avoid that by storing an hash of the url
in the post name and in case a matching hash is found rewrite
the file instead of creating a new one.