### PR TITLE
scripts: add telegram bot integration

### DIFF
--- a/scripts/post_telegram.php
+++ b/scripts/post_telegram.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+        Scrive sui canali telegram i prossimi eventi, tenendo traccia di quelli che già sono stati
+        notificati
+        Da invocare nello script di aggiornamento come
+        php scripts/post_telegram.php
+*/
+
+require_once('utils.php');
+
+$cachefile = 'scripts/cache/telegram.txt';
+$cached = file($cachefile);
+if (!$cached)
+	$cached = array();
+
+$events = futureEvents();
+
+$channels = $conf["telegram"]["channels"];
+$api_url = sprintf("https://api.telegram.org/bot%s/sendMessage", $conf["telegram"]["token"]);
+
+foreach($events as $event) {
+	$testable = sprintf("%s%s\n", $event['link'], $event['date']);
+	if (array_search($testable, $cached) !== false)
+		continue;
+
+	file_put_contents($cachefile, $testable, FILE_APPEND);
+	$date = date('d/m: ', strtotime($event['date']));
+
+	$append_url = sprintf(' %s', $event['link']);
+
+	/* Even if this is not twitter let's keep messages short */
+	$limit = 280 - strlen($date);
+	$title = substr($event['title'], 0, $limit);
+
+	$msg = sprintf('%s%s%s', $date, $title, $append_url);
+	foreach($channels as $channel) {
+		$data = array(
+			"chat_id" => $channel,
+			"text" => $msg,
+		);
+		doPost($api_url, http_build_query($data));
+	}
+	sleep(1);
+}
+

--- a/scripts/utils.php
+++ b/scripts/utils.php
@@ -18,6 +18,21 @@ function doGet($url) {
         return $resp;
 }
 
+function doPost($url, $data) {
+	$curl = curl_init();
+	curl_setopt_array($curl, array(
+		CURLOPT_RETURNTRANSFER => 1,
+		CURLOPT_URL => $url,
+		CURLOPT_USERAGENT => 'TorinoTechScene',
+		CURLOPT_POST => 1,
+		CURLOPT_POSTFIELDS => $data
+	));
+
+	$resp = curl_exec($curl);
+	curl_close($curl);
+	return $resp;
+}
+
 function readHostedGroups() {
         $data = Yaml::parse(file_get_contents('_data/groups.yml'));
         return $data;


### PR DESCRIPTION
Add a simple integration for posting events update in telegram
channels.
The following telegram configurations are required:
- token: a bot api token
- channels: the handlers of the channels

The bot should be invited to the channel.