### PR TITLE
config: use https in site url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-url: http://torinotechscene.it
+url: https://torinotechscene.it
 baseurl:
 timezone: Europe/Rome
 


### PR DESCRIPTION
This should fix browser warnings on favicon.ico being served over
http.