### PR TITLE
WIP Permettiamo di filtrare gli eventi eventbrite per titolo

### DIFF
--- a/_data/groups.yml
+++ b/_data/groups.yml
@@ -159,3 +159,5 @@
   img: codinggym.png
   description: Una palestra per allenarsi risolvendo in coppia esercizi di programmazione discutendo della propria soluzione con gli altri partecipanti.
   url: https://coding-gym.org/locations/turin/
+  source-eventbrite: 16859146671
+  eb-filter-title: Coding Gym Torino

--- a/scripts/fetch_eventbrite.php
+++ b/scripts/fetch_eventbrite.php
@@ -19,6 +19,14 @@ foreach($groups as $group) {
                 $resp = json_decode($resp);
 
                 foreach($resp->events as $event) {
+                        /* Permettiamo di filtrare gli eventi in base ad un testo presente nel titolo.
+                         * Utile quando usiamo lo stesso account per location diverse */
+                        if (isset($group['eb-filter-title'])) {
+                                if (strpos($event->name->text, $group['eb-filter-title']) === FALSE) {
+                                        continue;
+                                }
+                        }
+
                         $url = sprintf("https://www.eventbriteapi.com/v3/venues/%s/?token=%s", $event->venue_id, $token);
                         $venue_resp = doGet($url);
                         $venue_resp = json_decode($venue_resp);


### PR DESCRIPTION
[WIP perchè devo provarlo]

Capita di avere un account organizzatore condiviso per fare eventi
in diverse località. Permettiamo di far filtrare gli eventi per il
titolo che hanno su eventbrite in modo da non doverli mettere manualmente.
Questo mi permette di aggiungere Coding Gym Torino.